### PR TITLE
patch

### DIFF
--- a/proxy.conf
+++ b/proxy.conf
@@ -3,9 +3,9 @@ server {
     server_name localhost;
     access_log /var/log/nginx/localhost.access.log;
 
-    location PROXY_PREFIX/openrefine/ {
+    location PROXY_PREFIX/helloworld/ {
         proxy_buffering off;
-        proxy_pass         http://127.0.0.1:8000/;
-        proxy_redirect     http://127.0.0.1:8000/ PROXY_PREFIX/openrefine/;
+        proxy_pass         http://127.0.0.1:3333/;
+        proxy_redirect     http://127.0.0.1:3333/ PROXY_PREFIX/helloworld/;
     }
 }

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ cp /proxy.conf /etc/nginx/sites-enabled/default;
 
 #By default (and for security reasons) Refine only listens to TCP requests coming from localhost (127.0.0.1 on port 3333) . If you want to respond to TCP request coming to any Ip adress the machine has, #run refine like this from the command line :
 #./refine -i 0.0.0.0
-exec ../OpenRefine/refine -i 0.0.0.0 -p 80 -d /mnt/refine 
+exec ../OpenRefine/refine -d /mnt/refine &
 
 
 # Launch traffic monitor which will automatically kill the container if traffic


### PR DESCRIPTION
**proxy.conf**

In proxy.conf, `openrefine` had to be changed to `helloworld` as that is the name the GIE is currently under. 

When you rename all the `helloworld` files in https://github.com/ValentinChCloud/OpenRefine-galaxy-ie/tree/master/GIE to openrefine, then you should change the proxy.conf back

Additionally changed the proxy_pass to point to 3333 since that is the default port.

**startup.sh**

Tell the exec command to go into the background. Otherwise it just starts up the jetty server and is inaccessible. This allows the container startup to proceed and launch nginx + the traffic monitor.